### PR TITLE
add tolerance style: MORPH1_ONLY, MORPH2_ONLY (with/without opt. morph)

### DIFF
--- a/test.py
+++ b/test.py
@@ -336,6 +336,8 @@ def test_tolerance_style():
     assert parse_tolerance_style(u'로') == MORPH2_ONLY
     with pytest.raises(ValueError):
         parse_tolerance_style(u'이다')
+    with pytest.raises(ValueError):
+        parse_tolerance_style(u'만')
     parse_tolerance_style(u'(이)') == MORPH1_AND_OPTIONAL_MORPH2
     assert get_tolerance([u'예제'], OPTIONAL_MORPH2_AND_MORPH1) == u'예제'
     assert get_tolerance_from_iterator(iter([u'예제']),

--- a/test.py
+++ b/test.py
@@ -8,8 +8,8 @@ from tossi.hangul import join_phonemes, split_phonemes
 from tossi.particles import Euro, Ida, Particle, SingletonParticleMeta
 from tossi.tolerance import (
     generate_tolerances, get_tolerance, get_tolerance_from_iterator,
-    MORPH1_AND_OPTIONAL_MORPH2, OPTIONAL_MORPH2_AND_MORPH1, MORPH1_ONLY, MORPH2_ONLY,
-    parse_tolerance_style)
+    MORPH1_AND_OPTIONAL_MORPH2, MORPH1_ONLY, MORPH2_ONLY,
+    OPTIONAL_MORPH2_AND_MORPH1, parse_tolerance_style)
 
 
 Eun = get_particle(u'은')
@@ -333,6 +333,7 @@ def test_tolerance_style():
     assert parse_tolerance_style(u'을(를)') == MORPH1_AND_OPTIONAL_MORPH2
     assert parse_tolerance_style(u'(를)을') == OPTIONAL_MORPH2_AND_MORPH1
     assert parse_tolerance_style(u'과') == MORPH1_ONLY
+    assert parse_tolerance_style(u'로') == MORPH2_ONLY
     with pytest.raises(ValueError):
         parse_tolerance_style(u'이다')
     parse_tolerance_style(u'(이)') == MORPH1_AND_OPTIONAL_MORPH2

--- a/test.py
+++ b/test.py
@@ -8,7 +8,7 @@ from tossi.hangul import join_phonemes, split_phonemes
 from tossi.particles import Euro, Ida, Particle, SingletonParticleMeta
 from tossi.tolerance import (
     generate_tolerances, get_tolerance, get_tolerance_from_iterator,
-    MORPH1_AND_OPTIONAL_MORPH2, OPTIONAL_MORPH2_AND_MORPH1,
+    MORPH1_AND_OPTIONAL_MORPH2, OPTIONAL_MORPH2_AND_MORPH1, MORPH1_ONLY, MORPH2_ONLY,
     parse_tolerance_style)
 
 
@@ -67,19 +67,19 @@ def test_join_phonemes():
 
 def test_particle_tolerances():
     t = lambda _1, _2: set(generate_tolerances(_1, _2))
-    s = lambda x: set(x.split())
-    assert t(u'이', u'가') == s(u'이(가) (이)가 가(이) (가)이')
-    assert t(u'이', u'') == s(u'(이)')
-    assert t(u'으로', u'로') == s(u'(으)로')
-    assert t(u'이여', u'여') == s(u'(이)여')
-    assert t(u'이시여', u'시여') == s(u'(이)시여')
-    assert t(u'아', u'야') == s(u'아(야) (아)야 야(아) (야)아')
+    s = lambda x: set(x.split(' '))
+    assert t(u'이', u'가') == s(u'이(가) (이)가 가(이) (가)이 이 가')
+    assert t(u'이', u'') == s(u'(이) 이 ')
+    assert t(u'으로', u'로') == s(u'(으)로 으로 로')
+    assert t(u'이여', u'여') == s(u'(이)여 이여 여')
+    assert t(u'이시여', u'시여') == s(u'(이)시여 이시여 시여')
+    assert t(u'아', u'야') == s(u'아(야) (아)야 야(아) (야)아 아 야')
     assert \
         t(u'가나다', u'나나다') == \
-        s(u'가(나)나다 (가)나나다 나(가)나다 (나)가나다')
+        s(u'가(나)나다 (가)나나다 나(가)나다 (나)가나다 가나다 나나다')
     assert \
         t(u'가나다', u'마바사') == \
-        s(u'가나다(마바사) (가나다)마바사 마바사(가나다) (마바사)가나다')
+        s(u'가나다(마바사) (가나다)마바사 마바사(가나다) (마바사)가나다 가나다 마바사')
 
 
 def test_euro():
@@ -214,6 +214,8 @@ def test_tolerances():
     assert f(u'나오', u'(은)는') == u'나오는'
     assert f(u'나오', u'는(은)') == u'나오는'
     assert f(u'나오', u'(는)은') == u'나오는'
+    assert f(u'나오', u'은') == u'나오는'
+    assert f(u'나오', u'는') == u'나오는'
 
 
 def test_decimal():
@@ -330,12 +332,10 @@ def test_tolerance_style():
     assert parse_tolerance_style(0) == MORPH1_AND_OPTIONAL_MORPH2
     assert parse_tolerance_style(u'을(를)') == MORPH1_AND_OPTIONAL_MORPH2
     assert parse_tolerance_style(u'(를)을') == OPTIONAL_MORPH2_AND_MORPH1
-    with pytest.raises(ValueError):
-        parse_tolerance_style(u'과')
+    assert parse_tolerance_style(u'과') == MORPH1_ONLY
     with pytest.raises(ValueError):
         parse_tolerance_style(u'이다')
-    with pytest.raises(ValueError):
-        parse_tolerance_style(u'(이)')
+    parse_tolerance_style(u'(이)') == MORPH1_AND_OPTIONAL_MORPH2
     assert get_tolerance([u'예제'], OPTIONAL_MORPH2_AND_MORPH1) == u'예제'
     assert get_tolerance_from_iterator(iter([u'예제']),
                                        OPTIONAL_MORPH2_AND_MORPH1) == u'예제'

--- a/tossi/__init__.py
+++ b/tossi/__init__.py
@@ -15,9 +15,8 @@ import warnings
 from .coda import guess_coda
 from .particles import Euro, Ida, Particle
 from .tolerance import (
-    MORPH1_AND_OPTIONAL_MORPH2, MORPH2_AND_OPTIONAL_MORPH1,
-    OPTIONAL_MORPH1_AND_MORPH2, OPTIONAL_MORPH2_AND_MORPH1,
-    MORPH1_ONLY, MORPH2_ONLY,
+    MORPH1_AND_OPTIONAL_MORPH2, MORPH1_ONLY, MORPH2_AND_OPTIONAL_MORPH1,
+    MORPH2_ONLY, OPTIONAL_MORPH1_AND_MORPH2, OPTIONAL_MORPH2_AND_MORPH1,
     parse_tolerance_style)
 
 

--- a/tossi/__init__.py
+++ b/tossi/__init__.py
@@ -17,13 +17,14 @@ from .particles import Euro, Ida, Particle
 from .tolerance import (
     MORPH1_AND_OPTIONAL_MORPH2, MORPH2_AND_OPTIONAL_MORPH1,
     OPTIONAL_MORPH1_AND_MORPH2, OPTIONAL_MORPH2_AND_MORPH1,
+    MORPH1_ONLY, MORPH2_ONLY,
     parse_tolerance_style)
 
 
 __all__ = ['get_particle', 'guess_coda', 'MORPH1_AND_OPTIONAL_MORPH2',
            'MORPH2_AND_OPTIONAL_MORPH1', 'OPTIONAL_MORPH1_AND_MORPH2',
-           'OPTIONAL_MORPH2_AND_MORPH1', 'parse_tolerance_style', 'Particle',
-           'postfix_particle']
+           'OPTIONAL_MORPH2_AND_MORPH1', 'MORPH1_ONLY', 'MORPH2_ONLY',
+           'parse_tolerance_style', 'Particle', 'postfix_particle']
 
 
 def index_particles(particles):


### PR DESCRIPTION
tolerance style 옵션을 두 가지 추가해보았습니다.
일단 괄호를 표기하지 않고 싶어서, 어색하더라도 조사 중 하나를 default로 택1할 수 있도록 변경해보았습니다.
```python
>>> import tossi
>>> tossi.postfix_particle(u'さくら', u'이', tolerance_style=tossi.tolerance.MORPH2_ONLY)
さくら가
```

* morph1 vs. morph2 로 나뉘는 케이스 외에, '으로', '이다' 케이스는 다음과 같이 해석했습니다. 적절하지 않다면 말씀해주세요. :)
  - MORPH1_ONLY: with optional morph (longest)
  - MORPH2_ONLY: without optional morph (shortest)
* 수정하게 되는 변수/함수의 참조 범위를 다 체크하고 test.py의 모든 함수를 돌려보긴 했는데, 부작용이 없다고 95% 까지 밖에는 확신을 못 하겠네요 ㅠ
  - 일단 `generate_tolerance` 함수가 6개의 tolerance를 모두 생성해내도록 변경한게 가장 큰 것 같습니다.
* 이 내용이 원래 프로젝트가 추구하던 방향과 맞지 않는다든지 하다면, 더 나은 방안을 함께 논의해보고 이 PR을 drop하거나 수정해보도록 하겠습니다.