### PR TITLE
사용자 정의 tolerance_style 

### DIFF
--- a/test.py
+++ b/test.py
@@ -341,6 +341,12 @@ def test_tolerance_style():
                                        OPTIONAL_MORPH2_AND_MORPH1) == u'예제'
 
 
+def test_given_tolerance_style():
+    assert f(u'나오', u'을', tolerance_style=u'을/를') == u'나오를'
+    assert f(u'키홀', u'를', tolerance_style=u'을/를') == u'키홀을'
+    assert f(u'Tossi', u'을', tolerance_style=u'을/를') == u'Tossi을/를'
+
+
 def test_custom_guess_coda():
     def dont_guess_coda(word):
         return None

--- a/tossi/particles.py
+++ b/tossi/particles.py
@@ -13,7 +13,7 @@ from itertools import chain
 import re
 
 from bidict import bidict
-from six import PY2, python_2_unicode_compatible, with_metaclass
+from six import PY2, python_2_unicode_compatible, text_type, with_metaclass
 
 from .coda import guess_coda, pick_coda_from_letter
 from .hangul import combine_words, is_consonant, join_phonemes, split_phonemes
@@ -87,6 +87,9 @@ class Particle(with_metaclass(CacheMeta)):
         if coda is not None:
             # Coda guessed successfully.
             morph = self.rule(coda)
+        elif isinstance(tolerance_style, text_type):
+            # User specified the style themselves
+            morph = tolerance_style
         elif not suffix or not is_consonant(suffix[0]):
             # Choose the tolerant morph.
             morph = self.tolerance(tolerance_style)


### PR DESCRIPTION
tolerance_style에 문자열을 직접 지정할 수 있도록 기능을 추가합니다.

```
postfix_particle(u'나오', u'을', tolerance_style=u'을/를') == u'나오를'
postfix_particle(u'키홀', u'를', tolerance_style=u'을/를') == u'키홀을'
postfix_particle(u'Tossi', u'을', tolerance_style=u'을/를') == u'Tossi을/를'
```