### PR TITLE
문자열 포맷 API 추가

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import functools
+
 import pytest
 from six import PY2, text_type as str, with_metaclass
 
@@ -365,6 +367,15 @@ def test_custom_guess_coda():
 
 def test_unmatch():
     assert Eul[u'예제':u'는'] is None
+
+
+def test_formatter():
+    t = u'{0:으로} {0:을}'
+    f1 = functools.partial(tossi.Formatter(registry).format, t)
+    f2 = functools.partial(tossi.format, t)
+    assert f1(u'나오') == f2(u'나오') == u'나오로 나오를'
+    assert f1(u'키홀') == f2(u'키홀') == u'키홀로 키홀을'
+    assert f1(u'모리안') == f2(u'모리안') == u'모리안으로 모리안을'
 
 
 def test_singleton_error():

--- a/tossi/__init__.py
+++ b/tossi/__init__.py
@@ -13,6 +13,7 @@ import re
 import warnings
 
 from tossi.coda import guess_coda
+from tossi.formatter import Formatter
 from tossi.particles import Euro, Ida, Particle
 from tossi.tolerance import (
     MORPH1_AND_OPTIONAL_MORPH2, MORPH2_AND_OPTIONAL_MORPH1,
@@ -23,7 +24,8 @@ from tossi.tolerance import (
 __all__ = ['get_particle', 'guess_coda', 'MORPH1_AND_OPTIONAL_MORPH2',
            'MORPH2_AND_OPTIONAL_MORPH1', 'OPTIONAL_MORPH1_AND_MORPH2',
            'OPTIONAL_MORPH2_AND_MORPH1', 'parse', 'parse_tolerance_style',
-           'Particle', 'pick', 'postfix', 'postfix_particle']
+           'Particle', 'pick', 'postfix', 'postfix_particle',
+           'Formatter', 'format']
 
 
 def index_particles(particles):
@@ -107,6 +109,7 @@ registry = ParticleRegistry(Ida, [
     # Special particles:
     Euro,
 ])
+formatter = Formatter(registry)
 
 
 def parse(morph):
@@ -134,3 +137,9 @@ def get_particle(morph):
 def postfix_particle(word, morph, **kwargs):
     warnings.warn(DeprecationWarning('Use postfix() instead'))
     return postfix(word, morph, **kwargs)
+
+
+def format(message, *args, **kwargs):
+    """Shortcut for :class:`tossi.Formatter.format` of the default registry.
+    """
+    return formatter.vformat(message, args, kwargs)

--- a/tossi/formatter.py
+++ b/tossi/formatter.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+   tossi.formatter
+   ~~~~~~~~~~~~~~~
+
+   String formatter for Tossi.
+
+   :copyright: (c) 2016-2017 by What! Studio
+   :license: BSD, see LICENSE for more details.
+
+"""
+import re
+from string import Formatter as StringFormatter
+
+
+class Formatter(StringFormatter):
+    """String formatter supports tossi format spec.
+
+    >>> f = Formatter(tossi.registry)
+    >>> t = u'{0:으로} {0:을}'
+    >>> assert f.format(t, u'나오') == u'나오로 나오를'
+    >>> assert f.format(t, u'키홀') == u'키홀로 키홀을'
+    >>> assert f.format(t, u'모리안') == u'모리안으로 모리안을'
+    """
+    hangul_pattern = re.compile(u'[가-힣]+')
+
+    def __init__(self, registry):
+        self.registry = registry
+
+    def format_field(self, value, format_spec):
+        if re.match(self.hangul_pattern, format_spec):
+            return self.registry.postfix(value, format_spec)
+        else:
+            return super(Formatter, self).format_field(value, format_spec)


### PR DESCRIPTION
tossi.format 을 이용해 문자열에 조사를 포맷할수 있습니다.

ex) tossi.format('{0:을}', '나오') == '나오를'