### PR TITLE
Add a non-Korean test for Formatter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ ignore = E301, E731
 import_order_style = google
 application-import-names = tossi
 
-[pytest]
+[tool:pytest]
 python_files = test.py

--- a/test.py
+++ b/test.py
@@ -378,6 +378,10 @@ def test_formatter():
     assert f1(u'모리안') == f2(u'모리안') == u'모리안으로 모리안을'
 
 
+def test_formatter_without_korean():
+    assert tossi.format('{0}', u'Tossi') == u'Tossi'
+
+
 def test_singleton_error():
     with pytest.raises(TypeError):
         class Fail(with_metaclass(SingletonParticleMeta, object)):

--- a/tossi/coda.py
+++ b/tossi/coda.py
@@ -71,15 +71,15 @@ def filter_only_significant(word):
     x = len(word)
     while x > 0:
         x -= 1
-        l = word[x]
+        c = word[x]
         # Skip a complete parenthesis.
-        if l == u')':
+        if c == u')':
             m = INSIGNIFICANT_PARENTHESIS_PATTERN.search(word[:x + 1])
             if m is not None:
                 x = m.start()
             continue
         # Skip unreadable characters such as punctuations.
-        unicode_category = unicodedata.category(l)
+        unicode_category = unicodedata.category(c)
         if not SIGNIFICANT_UNICODE_CATEGORY_PATTERN.match(unicode_category):
             continue
         break

--- a/tossi/particles.py
+++ b/tossi/particles.py
@@ -229,7 +229,7 @@ class Euro(singleton_particle(Particle)):
 
 
 class Ida(singleton_particle(Particle)):
-    """"이다" is a verbal prticle.  Like other Korean verbs, it is also
+    """"이다" is a verbal particle.  Like other Korean verbs, it is also
     fusional.
     """
 

--- a/tossi/utils.py
+++ b/tossi/utils.py
@@ -19,7 +19,7 @@ def cached_property(f):
     """Similar to `@property` but it calls the function just once and caches
     the result.  The object has to can have ``__cache__`` attribute.
 
-    If you define `__slots__` for optimization, the metaclass should bea
+    If you define `__slots__` for optimization, the metaclass should be a
     :class:`CacheMeta`.
 
     """


### PR DESCRIPTION
To increase the coverage a little. Also fix a warning by replacing `[pytest]` with `[tool:pytest]` in `setup.cfg`.